### PR TITLE
fix gen_kruskal tuple bug

### DIFF
--- a/maze_dataset/generation/generators.py
+++ b/maze_dataset/generation/generators.py
@@ -440,8 +440,8 @@ class LatticeMazeGenerators:
 		assert lattice_dim == 2, (  # noqa: PLR2004
 			"Kruskal's algorithm is only implemented for 2D lattices."
 		)
-		# Convert grid_shape to a tuple of ints
-		grid_shape_: CoordTup = tuple(int(x) for x in grid_shape)  # type: ignore[assignment]
+		import numpy as np
+		grid_shape_: Coord = np.array([int(x) for x in grid_shape])
 		n_rows, n_cols = grid_shape_
 
 		# Initialize union-find data structure.
@@ -482,8 +482,6 @@ class LatticeMazeGenerators:
 		# Initialize connection_list with no connections.
 		# connection_list[0] stores downward connections (from cell (i,j) to (i+1,j)).
 		# connection_list[1] stores rightward connections (from cell (i,j) to (i,j+1)).
-		import numpy as np
-
 		connection_list = np.zeros((2, n_rows, n_cols), dtype=bool)
 
 		# Process each edge; if it connects two different trees, union them and carve the passage.
@@ -498,7 +496,7 @@ class LatticeMazeGenerators:
 					connection_list[1, cell1[0], cell1[1]] = True
 
 		if start_coord is None:
-			start_coord = tuple(np.random.randint(0, n) for n in grid_shape_)  # type: ignore[assignment]
+			start_coord = np.array([np.random.randint(0, n) for n in grid_shape_])  # type: ignore[assignment]
 
 		generation_meta: dict = dict(
 			func_name="gen_kruskal",

--- a/maze_dataset/generation/generators.py
+++ b/maze_dataset/generation/generators.py
@@ -440,7 +440,6 @@ class LatticeMazeGenerators:
 		assert lattice_dim == 2, (  # noqa: PLR2004
 			"Kruskal's algorithm is only implemented for 2D lattices."
 		)
-		import numpy as np
 		grid_shape_: Coord = np.array([int(x) for x in grid_shape])
 		n_rows, n_cols = grid_shape_
 
@@ -545,7 +544,7 @@ class LatticeMazeGenerators:
 			"Recursive division algorithm is only implemented for 2D lattices."
 		)
 		# Convert grid_shape to a tuple of ints.
-		grid_shape_: CoordTup = tuple(int(x) for x in grid_shape)  # type: ignore[assignment]
+		grid_shape_: Coord = np.array([int(x) for x in grid_shape])
 		n_rows, n_cols = grid_shape_
 
 		# Initialize connection_list as a fully connected grid.
@@ -594,7 +593,7 @@ class LatticeMazeGenerators:
 		divide(0, 0, n_cols, n_rows)
 
 		if start_coord is None:
-			start_coord = tuple(np.random.randint(0, n) for n in grid_shape_)  # type: ignore[assignment]
+			start_coord = np.array([np.random.randint(0, n) for n in grid_shape_])  # type: ignore[assignment]
 
 		generation_meta: dict = dict(
 			func_name="gen_recursive_division",


### PR DESCRIPTION
Had a bug while trying to generate maze with gen_kruskal. This commit fixes it.
Please let me know if this is not the intended way to use gen_kruskal.

Here's a script that fails on `main` without this commit - 
```py
from maze_dataset import MazeDataset, MazeDatasetConfig
from maze_dataset.generation import LatticeMazeGenerators

cfg1 = MazeDatasetConfig(
    name="demo",
    grid_n=5,
    n_mazes=1000,
    maze_ctor=LatticeMazeGenerators.gen_kruskal,
)

cfg2 = MazeDatasetConfig(
    name="demo",
    grid_n=5,
    n_mazes=1000,
    maze_ctor=LatticeMazeGenerators.gen_recursive_division,
)

dataset1 = MazeDataset.from_config(cfg1)
dataset2 = MazeDataset.from_config(cfg2)

print("done")
```